### PR TITLE
feat: add Firefox support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cut",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "src/popup.tsx",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "copy the URL and Title",
   "manifest_version": 3,
-  "version": "0.1",
+  "version": "0.1.0",
   "action": {
     "default_title": "CUT",
     "default_popup": "popup.html"
@@ -12,6 +12,13 @@
     "128": "icon128.png"
   },
   "permissions": [
-    "tabs"
-  ]
+    "tabs",
+    "clipboardWrite"
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "cut@shota-tsuji",
+      "strict_min_version": "109.0"
+    }
+  }
 }

--- a/src/infrastructure/BrowserTabRepository.ts
+++ b/src/infrastructure/BrowserTabRepository.ts
@@ -1,10 +1,11 @@
 import {IPageInfoRepository} from "../domain/IPageInfoRepository";
 import PageInfo, {Format} from "../domain/PageInfo";
+import browserApi from "./browserApi";
 
-export default class ChromeTabRepository implements IPageInfoRepository {
+export default class BrowserTabRepository implements IPageInfoRepository {
     async getPageInfo(): Promise<PageInfo> {
         let queryOptions = {active: true, lastFocusedWindow: true};
-        let [tab] = await chrome.tabs.query(queryOptions);
+        let [tab] = await browserApi.tabs.query(queryOptions);
 
         if (!tab.url || !tab.title) {
             return new PageInfo('', '');

--- a/src/infrastructure/browserApi.ts
+++ b/src/infrastructure/browserApi.ts
@@ -1,0 +1,8 @@
+/**
+ * Firefox exposes the promise-based WebExtension APIs on `browser`, Chrome only
+ * on `chrome`. Chrome's MV3 `chrome.*` returns promises too, so preferring
+ * `browser` when it exists gives promises on both browsers without a polyfill.
+ */
+const browserApi: typeof chrome = (globalThis as any).browser ?? chrome;
+
+export default browserApi;

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,7 +1,7 @@
 import {createTheme, CssBaseline, ThemeProvider} from "@mui/material";
 import OutlinedCard from "./components/OutlinedCard";
 import {IPageInfoRepository} from "./domain/IPageInfoRepository";
-import ChromeTabRepository from "./infrastructure/ChromeTabRepository";
+import BrowserTabRepository from "./infrastructure/BrowserTabRepository";
 import {createRoot} from "react-dom/client";
 import {Format} from "./domain/PageInfo";
 import * as React from "react";
@@ -47,5 +47,5 @@ class PopupService {
     }
 }
 
-const popupService = new PopupService(new ChromeTabRepository());
+const popupService = new PopupService(new BrowserTabRepository());
 void popupService.main();


### PR DESCRIPTION
Manifest was already MV3, so the gap was Firefox-specific:

- Add browser_specific_settings.gecko.id, required for Firefox to sign and permanently install an MV3 extension. Chrome ignores the key, so a single manifest still serves both browsers.
- Add strict_min_version 109.0, Firefox's first MV3 release.
- Add clipboardWrite, which Firefox requires for navigator.clipboard.writeText outside a user gesture.
- Introduce browserApi, which prefers Firefox's promise-based `browser` namespace and falls back to `chrome`, whose MV3 APIs are also promise-based. This keeps `await tabs.query(...)` working on both without a polyfill.
- Rename ChromeTabRepository to BrowserTabRepository now that it is no longer Chrome-specific.
- Sync manifest and package.json to 0.1.0. AMO rejects re-uploads of an already published version, so the two must not drift.

Verified with `npm run build` and `web-ext lint` (0 errors, 0 notices).