### PR TITLE
feat: add keyboard shortcut to open the popup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dist/**/*
 
 # ignore yarn.lock
 yarn.lock
+# macOS
+.DS_Store

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,6 +6,15 @@
     "default_title": "CUT",
     "default_popup": "popup.html"
   },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+U",
+        "mac": "Command+Shift+U"
+      },
+      "description": "Open the CUT popup"
+    }
+  },
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",


### PR DESCRIPTION
Bind the reserved _execute_action command to Ctrl+Shift+U
(Command+Shift+U on macOS) so the popup can be opened without reaching
for the toolbar button.

_execute_action is handled by the browser itself, so this needs no
background script and works on both Firefox 109+ and Chrome. Users can
rebind or clear it from about:addons "Manage Extension Shortcuts" in
Firefox, or chrome://extensions/shortcuts in Chrome.

Ctrl+Shift+U avoids Firefox's built-in bindings; the nearby
Ctrl+Shift+{A,C,E,I,J,K,M} are taken by the add-ons manager and devtools.

Verified with `web-ext lint` (0 errors, 0 notices).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
